### PR TITLE
Feat: anaconda auth fallback

### DIFF
--- a/examples/github-oauth/agent.py
+++ b/examples/github-oauth/agent.py
@@ -207,7 +207,8 @@ def get_github_token(server_url: str = "http://localhost:8080") -> str:
         # Open browser
         webbrowser.open(auth_url)
         
-        # Wait for callback
+        # Wait for callback - enable address reuse to avoid "Address already in use" errors
+        socketserver.TCPServer.allow_reuse_address = True
         with socketserver.TCPServer(("", callback_port), CallbackHandler) as httpd:
             httpd.timeout = 120  # 2 minute timeout
             httpd.handle_request()

--- a/mcp_compose/__version__.py
+++ b/mcp_compose/__version__.py
@@ -1,3 +1,3 @@
 """Version information for mcp_compose."""
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"

--- a/mcp_compose/api/middleware.py
+++ b/mcp_compose/api/middleware.py
@@ -96,18 +96,8 @@ class AuthenticationMiddleware:
                 token = auth_str[7:]
                 credentials["token"] = token
         
-        # If no credentials provided, return 401
-        if not credentials:
-            logger.warning(f"No credentials provided for path: {path}")
-            response = JSONResponse(
-                status_code=401,
-                content={"detail": "Authentication required"},
-                headers={"WWW-Authenticate": "Bearer"},
-            )
-            await response(scope, receive, send)
-            return
-        
-        # Authenticate
+        # Authenticate - pass empty credentials to authenticator
+        # (fallback mode authenticators can handle empty credentials)
         try:
             context = await _authenticator.authenticate(credentials)
             # Authentication succeeded - continue to app

--- a/mcp_compose/api/middleware.py
+++ b/mcp_compose/api/middleware.py
@@ -27,7 +27,18 @@ class AuthenticationMiddleware:
     """
     
     # Paths that don't require authentication
-    PUBLIC_PATHS = {"/docs", "/redoc", "/openapi.json", "/api/v1/health"}
+    PUBLIC_PATHS = {
+        "/docs", 
+        "/redoc", 
+        "/openapi.json", 
+        "/api/v1/health",
+        "/authorize",
+        "/oauth/callback",
+        "/token",
+        "/register",
+        "/.well-known/oauth-authorization-server",
+        "/.well-known/oauth-protected-resource",
+    }
     
     def __init__(self, app: ASGIApp):
         """

--- a/mcp_compose/auth.py
+++ b/mcp_compose/auth.py
@@ -366,7 +366,10 @@ def create_authenticator(auth_type: AuthType, **kwargs) -> Authenticator:
         return APIKeyAuthenticator(api_keys=kwargs.get("api_keys"))
     elif auth_type == AuthType.ANACONDA:
         from .providers.auth_anaconda import AnacondaAuthenticator
-        return AnacondaAuthenticator(domain=kwargs.get("domain", "anaconda.com"))
+        return AnacondaAuthenticator(
+            domain=kwargs.get("domain", "anaconda.com"),
+            fallback_mode=kwargs.get("fallback_mode", False)
+        )
     elif auth_type == AuthType.OAUTH2:
         from .auth_oauth2 import (
             create_generic_oauth2_authenticator,

--- a/mcp_compose/cli.py
+++ b/mcp_compose/cli.py
@@ -385,7 +385,6 @@ async def run_server(config, args: argparse.Namespace) -> int:
     
     # Create discovery with config directory as project root for embedded server imports
     from .discovery import MCPServerDiscovery
-    from pathlib import Path
     config_dir = Path(args.config_path).parent
     discovery = MCPServerDiscovery(project_root=config_dir)
     

--- a/references/oauth/config.template.json.disabled
+++ b/references/oauth/config.template.json.disabled
@@ -2,9 +2,12 @@
   "_comment_1": "Configuration Template",
   "_comment_2": "Copy this file to config.json and fill in your GitHub OAuth credentials",
   "_comment_3": "Get credentials from: https://github.com/settings/developers",
-  "_comment_4": "Create OAuth App with callback URL: http://localhost:8080/callback",
+  "_comment_4": "Create OAuth App with callback URL: http://localhost:8080/oauth/callback",
   
-  "github": {
+  "oauth": {
+    "authorization_endpoint": "https://github.com/login/oauth/authorize",
+    "token_endpoint": "https://github.com/login/oauth/access_token",
+    "userinfo_endpoint": "https://api.github.com/user",
     "client_id": "Iv1.YOUR_CLIENT_ID_HERE",
     "client_secret": "YOUR_CLIENT_SECRET_HERE"
   },

--- a/references/oauth/mcp_oauth_example/oauth_client.py
+++ b/references/oauth/mcp_oauth_example/oauth_client.py
@@ -44,11 +44,23 @@ class Config:
     
     @property
     def github_client_id(self) -> str:
-        return self.config["github"]["client_id"]
+        return self.config["oauth"]["client_id"]
     
     @property
     def github_client_secret(self) -> str:
-        return self.config["github"]["client_secret"]
+        return self.config["oauth"]["client_secret"]
+    
+    @property
+    def authorization_endpoint(self) -> str:
+        return self.config["oauth"]["authorization_endpoint"]
+    
+    @property
+    def token_endpoint(self) -> str:
+        return self.config["oauth"]["token_endpoint"]
+    
+    @property
+    def userinfo_endpoint(self) -> str:
+        return self.config["oauth"]["userinfo_endpoint"]
     
     @property
     def server_url(self) -> str:

--- a/references/oauth/mcp_oauth_example/server.py
+++ b/references/oauth/mcp_oauth_example/server.py
@@ -49,11 +49,23 @@ class Config:
     
     @property
     def github_client_id(self) -> str:
-        return self.config["github"]["client_id"]
+        return self.config["oauth"]["client_id"]
     
     @property
     def github_client_secret(self) -> str:
-        return self.config["github"]["client_secret"]
+        return self.config["oauth"]["client_secret"]
+    
+    @property
+    def authorization_endpoint(self) -> str:
+        return self.config["oauth"]["authorization_endpoint"]
+    
+    @property
+    def token_endpoint(self) -> str:
+        return self.config["oauth"]["token_endpoint"]
+    
+    @property
+    def userinfo_endpoint(self) -> str:
+        return self.config["oauth"]["userinfo_endpoint"]
     
     @property
     def server_host(self) -> str:
@@ -93,7 +105,7 @@ class TokenValidator:
         # Validate with GitHub
         try:
             response = requests.get(
-                "https://api.github.com/user",
+                config.userinfo_endpoint,
                 headers={
                     "Authorization": f"Bearer {token}",
                     "Accept": "application/vnd.github.v3+json"
@@ -709,7 +721,7 @@ async def authorize(request: Request):
         "allow_signup": "false"
     }
     
-    github_auth_url = "https://github.com/login/oauth/authorize?" + urlencode(github_params)
+    github_auth_url = config.authorization_endpoint + "?" + urlencode(github_params)
     return RedirectResponse(url=github_auth_url)
 
 
@@ -752,7 +764,7 @@ async def oauth_callback_github(request: Request):
     try:
         logger.info(f"Exchanging GitHub code for access token...")
         token_resp = requests.post(
-            "https://github.com/login/oauth/access_token",
+            config.token_endpoint,
             headers={"Accept": "application/json"},
             json={
                 "client_id": config.github_client_id,
@@ -773,7 +785,7 @@ async def oauth_callback_github(request: Request):
         # Fetch user info from GitHub
         logger.info(f"Fetching user info from GitHub...")
         user_resp = requests.get(
-            "https://api.github.com/user",
+            config.userinfo_endpoint,
             headers={
                 "Authorization": f"Bearer {gh_token}",
                 "Accept": "application/json"


### PR DESCRIPTION
1. **Server Side**: When `MCP_COMPOSE_ANACONDA_TOKEN="fallback"`, the server will:
   - Accept requests with `Authorization: Bearer <token>` headers and validate them (normal mode)
   - Accept requests **without** Bearer tokens and attempt to retrieve a token from its local `anaconda_auth` library:
     ```python
     from anaconda_auth.token import TokenInfo
     token = TokenInfo(domain="anaconda.com").get_access_token()
     ```
   - Reject requests if neither a valid Bearer token is provided nor a local token can be retrieved

2. **Client Side**: When `MCP_COMPOSE_ANACONDA_TOKEN="fallback"`, the agent will:
   - **Not send** an `Authorization: Bearer <token>` header
   - Let the server use its local `anaconda_auth` token
   - Skip the interactive login/authentication flow

3. **Validation**: If a token is found (either from request or local), it's validated. If no token can be obtained, the request is rejected with 401 Unauthorized.

