### PR TITLE
fix: replace deprecated streamablehttp_client to prevent connection pool hang

### DIFF
--- a/examples/anaconda-token/agent.py
+++ b/examples/anaconda-token/agent.py
@@ -236,15 +236,15 @@ def main():
             try:
                 # Import MCP SDK client for streamable HTTP
                 from mcp import ClientSession
-                from mcp.client.streamable_http import streamablehttp_client
-                
+                from mcp_compose.http_client import streamable_http_client_compat
+
                 # Build headers - only add Authorization if we have a token
                 headers = {}
                 if access_token:
                     headers["Authorization"] = f"Bearer {access_token}"
-                
-                # Connect using Streamable HTTP client
-                async with streamablehttp_client(
+
+                # Connect using Streamable HTTP client (non-deprecated)
+                async with streamable_http_client_compat(
                     "http://localhost:8080/mcp",
                     headers=headers if headers else None
                 ) as (read, write, _):

--- a/mcp_compose/cli.py
+++ b/mcp_compose/cli.py
@@ -25,6 +25,9 @@ from .process_manager import ProcessManager
 logger = logging.getLogger(__name__)
 
 
+from .http_client import streamable_http_client_compat
+
+
 def setup_logging(verbose: bool = False) -> None:
     """Set up logging configuration."""
     level = logging.DEBUG if verbose else logging.INFO
@@ -783,8 +786,7 @@ async def run_server(config, args: argparse.Namespace) -> int:
                             )
 
                             if protocol_value == "streamable-http":
-                                # Use native MCP streamablehttp_client
-                                from mcp.client.streamable_http import streamablehttp_client
+                                # Use non-deprecated streamable_http_client via helper
 
                                 # Build headers for authentication
                                 headers = {}
@@ -800,7 +802,7 @@ async def run_server(config, args: argparse.Namespace) -> int:
                                     else:
                                         headers["Authorization"] = server_config.auth_token
 
-                                async with streamablehttp_client(
+                                async with streamable_http_client_compat(
                                     url=server_config.url,
                                     headers=headers if headers else None,
                                     timeout=float(server_config.timeout),
@@ -841,9 +843,6 @@ async def run_server(config, args: argparse.Namespace) -> int:
                                                 async def streamable_http_tool_proxy(**kwargs):
                                                     """Proxy function for streamable HTTP tool."""
                                                     from mcp import ClientSession
-                                                    from mcp.client.streamable_http import (
-                                                        streamablehttp_client,
-                                                    )
 
                                                     # Build headers for authentication
                                                     hdrs = {}
@@ -866,7 +865,7 @@ async def run_server(config, args: argparse.Namespace) -> int:
                                                                 http_config.auth_token
                                                             )
 
-                                                    async with streamablehttp_client(
+                                                    async with streamable_http_client_compat(
                                                         url=http_config.url,
                                                         headers=hdrs if hdrs else None,
                                                         timeout=float(http_config.timeout),
@@ -1077,7 +1076,6 @@ async def run_server(config, args: argparse.Namespace) -> int:
             import time
 
             from mcp import ClientSession
-            from mcp.client.streamable_http import streamablehttp_client
 
             from .config import StreamableHttpProxiedServerConfig
 
@@ -1131,7 +1129,7 @@ async def run_server(config, args: argparse.Namespace) -> int:
                                 else:
                                     headers["Authorization"] = server_config.auth_token
 
-                            async with streamablehttp_client(
+                            async with streamable_http_client_compat(
                                 url=server_config.url,
                                 headers=headers if headers else None,
                                 timeout=float(server_config.timeout),
@@ -1182,9 +1180,6 @@ async def run_server(config, args: argparse.Namespace) -> int:
                                         async def streamable_http_tool_proxy(**kwargs):
                                             """Proxy function for streamable HTTP tool."""
                                             from mcp import ClientSession
-                                            from mcp.client.streamable_http import (
-                                                streamablehttp_client,
-                                            )
 
                                             # Build headers for authentication
                                             hdrs = {}
@@ -1200,7 +1195,7 @@ async def run_server(config, args: argparse.Namespace) -> int:
                                                 else:
                                                     hdrs["Authorization"] = http_config.auth_token
 
-                                            async with streamablehttp_client(
+                                            async with streamable_http_client_compat(
                                                 url=http_config.url,
                                                 headers=hdrs if hdrs else None,
                                                 timeout=float(http_config.timeout),

--- a/mcp_compose/http_client.py
+++ b/mcp_compose/http_client.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2025-2026 Datalayer, Inc.
+# Distributed under the terms of the Modified BSD License.
+
+"""
+HTTP client utilities for MCP Compose.
+
+Provides compatibility wrapper for the MCP SDK's streamable HTTP client.
+"""
+
+import httpx
+from contextlib import asynccontextmanager
+from mcp.client.streamable_http import streamable_http_client
+
+
+def streamable_http_client_compat(url, headers=None, timeout=30, verify=True):
+    """
+    Compatibility wrapper that provides the same interface as the deprecated
+    streamablehttp_client but uses the non-deprecated streamable_http_client.
+
+    This avoids the 5-minute SSE read timeout issue that causes connection pool
+    corruption when tool handlers return quickly (inline 200 OK response path).
+
+    See: https://github.com/modelcontextprotocol/python-sdk/issues/1941
+
+    Args:
+        url: The MCP server URL (e.g., "http://localhost:8080/mcp")
+        headers: Optional dict of HTTP headers (e.g., {"Authorization": "Bearer ..."})
+        timeout: Request timeout in seconds (default: 30)
+        verify: SSL certificate verification (default: True). Set to False for localhost dev.
+
+    Returns:
+        Async context manager yielding (read_stream, write_stream, get_session_id)
+
+    Usage:
+        async with streamable_http_client_compat(
+            url="http://localhost:8080/mcp",
+            headers={"Authorization": "Bearer token"},
+            timeout=30,
+        ) as (read_stream, write_stream, get_session_id):
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+                result = await session.call_tool("tool_name", {"arg": "value"})
+    """
+
+    @asynccontextmanager
+    async def _context():
+        async with httpx.AsyncClient(
+            headers=headers,
+            timeout=httpx.Timeout(float(timeout)),
+            verify=verify,
+        ) as http_client:
+            async with streamable_http_client(
+                url=url,
+                http_client=http_client,
+            ) as streams:
+                yield streams
+
+    return _context()

--- a/references/oauth/mcp_oauth_example/client.py
+++ b/references/oauth/mcp_oauth_example/client.py
@@ -30,8 +30,7 @@ from .oauth_client import OAuthClient
 # MCP client imports
 try:
     from mcp import ClientSession
-    from mcp.client.streamable_http import streamablehttp_client
-    import httpx
+    from mcp_compose.http_client import streamable_http_client_compat
     HAS_MCP = True
 except ImportError:
     HAS_MCP = False
@@ -91,22 +90,18 @@ class MCPClient:
                 # Disable SSL verification for localhost (development with mkcert)
                 server_url = self.oauth.get_server_url()
                 verify_ssl = not server_url.startswith("https://localhost")
-                
-                # Create HTTP client with auth headers
-                async with httpx.AsyncClient(
+
+                # Connect using non-deprecated streamable HTTP client
+                async with streamable_http_client_compat(
+                    f"{self.oauth.get_server_url()}/mcp",
                     headers={"Authorization": f"Bearer {self.access_token}"},
                     timeout=30.0,
-                    verify=verify_ssl
-                ) as http_client:
-                    # Connect using MCP SDK's streamable HTTP client
-                    async with streamablehttp_client(
-                        f"{self.oauth.get_server_url()}/mcp",
-                        http_client=http_client
-                    ) as (read_stream, write_stream):
-                        async with ClientSession(read_stream, write_stream) as session:
-                            await session.initialize()
-                            tools_list = await session.list_tools()
-                            return tools_list
+                    verify=verify_ssl,
+                ) as (read_stream, write_stream, _):
+                    async with ClientSession(read_stream, write_stream) as session:
+                        await session.initialize()
+                        tools_list = await session.list_tools()
+                        return tools_list
             
             # Run async function
             tools_list = asyncio.run(_list_tools())
@@ -153,44 +148,40 @@ class MCPClient:
             # Disable SSL verification for localhost (development with mkcert)
             server_url = self.oauth.get_server_url()
             verify_ssl = not server_url.startswith("https://localhost")
-            
-            # Create HTTP client with auth headers
-            async with httpx.AsyncClient(
+
+            # Connect using non-deprecated streamable HTTP client
+            async with streamable_http_client_compat(
+                f"{self.oauth.get_server_url()}/mcp",
                 headers={"Authorization": f"Bearer {self.access_token}"},
                 timeout=30.0,
-                verify=verify_ssl
-            ) as http_client:
-                # Connect to MCP server via HTTP streaming
-                async with streamablehttp_client(
-                    f"{self.oauth.get_server_url()}/mcp",
-                    http_client=http_client
-                ) as (read_stream, write_stream):
-                    async with ClientSession(read_stream, write_stream) as session:
-                        # Initialize the session
-                        await session.initialize()
-                        
-                        # Call the tool
-                        result = await session.call_tool(tool_name, arguments)
-                        
-                        # Extract content from result
-                        if hasattr(result, 'content'):
-                            content = result.content
-                            if isinstance(content, list) and len(content) > 0:
-                                # Get the text content from the first item
-                                first_content = content[0]
-                                if hasattr(first_content, 'text'):
-                                    result_text = first_content.text
-                                else:
-                                    result_text = str(first_content)
+                verify=verify_ssl,
+            ) as (read_stream, write_stream, _):
+                async with ClientSession(read_stream, write_stream) as session:
+                    # Initialize the session
+                    await session.initialize()
+
+                    # Call the tool
+                    result = await session.call_tool(tool_name, arguments)
+
+                    # Extract content from result
+                    if hasattr(result, 'content'):
+                        content = result.content
+                        if isinstance(content, list) and len(content) > 0:
+                            # Get the text content from the first item
+                            first_content = content[0]
+                            if hasattr(first_content, 'text'):
+                                result_text = first_content.text
                             else:
-                                result_text = str(content)
+                                result_text = str(first_content)
                         else:
-                            result_text = str(result)
-                        
-                        print(f"✅ Tool invoked successfully")
-                        print(f"   Result: {result_text}")
-                        
-                        return result
+                            result_text = str(content)
+                    else:
+                        result_text = str(result)
+
+                    print(f"✅ Tool invoked successfully")
+                    print(f"   Result: {result_text}")
+
+                    return result
         
         except Exception as e:
             print(f"❌ Error invoking tool: {e}")


### PR DESCRIPTION
Fixes #27                                                                                                                                                                                                                                                                                                                                                             
                                                            
  ## Summary
  - Add `mcp_compose/http_client.py` with `streamable_http_client_compat()` helper
  - Replace all usages of deprecated `streamablehttp_client` with the new helper
  - Helper uses non-deprecated `streamable_http_client` with explicit `httpx.AsyncClient`

  ## Changed files
  - `mcp_compose/http_client.py` (new)
  - `mcp_compose/cli.py`
  - `examples/anaconda-token/agent.py`
  - `references/oauth/mcp_oauth_example/client.py`

  ## Test results
  - Unit tests: 514 passed
  - E2E: 50+ iterations pass (previously hung at iteration 4)