### PR TITLE
pass clientinfo from client to tools

### DIFF
--- a/mcp_compose/cli.py
+++ b/mcp_compose/cli.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from .composer import ConflictResolution, MCPServerComposer
 from .config_loader import find_config_file, load_config
+from .client_info import resolve_client_info
 from .discovery import MCPServerDiscovery
 from .exceptions import MCPComposerError
 from .http_client import streamable_http_client_compat
@@ -675,14 +676,17 @@ async def run_server(config, args: argparse.Namespace) -> int:
                                     def make_sse_proxy(sse_url: str, original_tool_name: str):
                                         """Create a proxy function that calls the remote SSE server."""
 
-                                        async def sse_tool_proxy(**kwargs):
+                                        async def sse_tool_proxy(ctx=None, **kwargs):
                                             """Proxy function for SSE tool."""
                                             from mcp import ClientSession
                                             from mcp.client.sse import sse_client
 
+                                            client_info = resolve_client_info(ctx)
                                             # Connect to SSE server and call the tool
                                             async with sse_client(sse_url) as (read, write):
-                                                async with ClientSession(read, write) as session:
+                                                async with ClientSession(
+                                                    read, write, client_info=client_info
+                                                ) as session:
                                                     await session.initialize()
                                                     result = await session.call_tool(
                                                         original_tool_name, kwargs
@@ -861,10 +865,11 @@ async def run_server(config, args: argparse.Namespace) -> int:
                                             ):
                                                 """Create a proxy function that calls the remote streamable HTTP server."""
 
-                                                async def streamable_http_tool_proxy(**kwargs):
+                                                async def streamable_http_tool_proxy(ctx=None, **kwargs):
                                                     """Proxy function for streamable HTTP tool."""
                                                     from mcp import ClientSession
 
+                                                    client_info = resolve_client_info(ctx)
                                                     # Build headers for authentication
                                                     hdrs = {}
                                                     if http_config.auth_token:
@@ -896,7 +901,8 @@ async def run_server(config, args: argparse.Namespace) -> int:
                                                         get_session_id,
                                                     ):
                                                         async with ClientSession(
-                                                            read_stream, write_stream
+                                                            read_stream, write_stream,
+                                                            client_info=client_info,
                                                         ) as session:
                                                             await session.initialize()
                                                             result = await session.call_tool(
@@ -1001,7 +1007,7 @@ async def run_server(config, args: argparse.Namespace) -> int:
                                         def make_http_proxy(http_config, original_tool_name: str):
                                             """Create a proxy function that calls the remote HTTP server."""
 
-                                            async def http_tool_proxy(**kwargs):
+                                            async def http_tool_proxy(ctx=None, **kwargs):
                                                 """Proxy function for HTTP tool."""
                                                 from mcp import ClientSession
 
@@ -1009,6 +1015,7 @@ async def run_server(config, args: argparse.Namespace) -> int:
                                                     create_http_stream_transport,
                                                 )
 
+                                                client_info = resolve_client_info(ctx)
                                                 # Connect to HTTP server and call the tool
                                                 transport = await create_http_stream_transport(
                                                     name=http_config.name,
@@ -1021,7 +1028,8 @@ async def run_server(config, args: argparse.Namespace) -> int:
 
                                                 try:
                                                     async with ClientSession(
-                                                        transport.messages(), transport.send
+                                                        transport.messages(), transport.send,
+                                                        client_info=client_info,
                                                     ) as session:
                                                         await session.initialize()
                                                         result = await session.call_tool(
@@ -1198,10 +1206,11 @@ async def run_server(config, args: argparse.Namespace) -> int:
                                     ):
                                         """Create a proxy function that calls the remote streamable HTTP server."""
 
-                                        async def streamable_http_tool_proxy(**kwargs):
+                                        async def streamable_http_tool_proxy(ctx=None, **kwargs):
                                             """Proxy function for streamable HTTP tool."""
                                             from mcp import ClientSession
 
+                                            client_info = resolve_client_info(ctx)
                                             # Build headers for authentication
                                             hdrs = {}
                                             if http_config.auth_token:
@@ -1222,7 +1231,8 @@ async def run_server(config, args: argparse.Namespace) -> int:
                                                 timeout=float(http_config.timeout),
                                             ) as (read_stream, write_stream, get_session_id):
                                                 async with ClientSession(
-                                                    read_stream, write_stream
+                                                    read_stream, write_stream,
+                                                    client_info=client_info,
                                                 ) as session:
                                                     await session.initialize()
                                                     result = await session.call_tool(

--- a/mcp_compose/cli.py
+++ b/mcp_compose/cli.py
@@ -16,9 +16,9 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .client_info import resolve_client_info
 from .composer import ConflictResolution, MCPServerComposer
 from .config_loader import find_config_file, load_config
-from .client_info import resolve_client_info
 from .discovery import MCPServerDiscovery
 from .exceptions import MCPComposerError
 from .http_client import streamable_http_client_compat
@@ -865,7 +865,9 @@ async def run_server(config, args: argparse.Namespace) -> int:
                                             ):
                                                 """Create a proxy function that calls the remote streamable HTTP server."""
 
-                                                async def streamable_http_tool_proxy(ctx=None, **kwargs):
+                                                async def streamable_http_tool_proxy(
+                                                    ctx=None, **kwargs
+                                                ):
                                                     """Proxy function for streamable HTTP tool."""
                                                     from mcp import ClientSession
 
@@ -901,7 +903,8 @@ async def run_server(config, args: argparse.Namespace) -> int:
                                                         get_session_id,
                                                     ):
                                                         async with ClientSession(
-                                                            read_stream, write_stream,
+                                                            read_stream,
+                                                            write_stream,
                                                             client_info=client_info,
                                                         ) as session:
                                                             await session.initialize()
@@ -1028,7 +1031,8 @@ async def run_server(config, args: argparse.Namespace) -> int:
 
                                                 try:
                                                     async with ClientSession(
-                                                        transport.messages(), transport.send,
+                                                        transport.messages(),
+                                                        transport.send,
                                                         client_info=client_info,
                                                     ) as session:
                                                         await session.initialize()
@@ -1231,7 +1235,8 @@ async def run_server(config, args: argparse.Namespace) -> int:
                                                 timeout=float(http_config.timeout),
                                             ) as (read_stream, write_stream, get_session_id):
                                                 async with ClientSession(
-                                                    read_stream, write_stream,
+                                                    read_stream,
+                                                    write_stream,
                                                     client_info=client_info,
                                                 ) as session:
                                                     await session.initialize()

--- a/mcp_compose/client_info.py
+++ b/mcp_compose/client_info.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2025-2026 Datalayer, Inc.
+# Distributed under the terms of the Modified BSD License.
+
+from typing import Any
+
+from mcp.types import Implementation
+
+FALLBACK_CLIENT_INFO = Implementation(name="mcp-compose", version="0.1.0")
+
+
+def resolve_client_info(ctx: Any = None) -> Implementation:
+    """Return upstream clientInfo from a FastMCP Context, or the mcp-compose fallback."""
+    try:
+        if ctx is not None:
+            client_params = ctx.session.client_params
+            if client_params is not None:
+                return client_params.clientInfo
+    except AttributeError:
+        pass
+    return FALLBACK_CLIENT_INFO

--- a/mcp_compose/otel.py
+++ b/mcp_compose/otel.py
@@ -566,7 +566,9 @@ def _instrument_tool_proxy(
     original_discover_tools = ToolProxy.discover_tools
 
     @functools.wraps(original_discover_tools)
-    async def traced_discover_tools(self: Any, server_name: str, process: Any, ctx: Any = None) -> None:
+    async def traced_discover_tools(
+        self: Any, server_name: str, process: Any, ctx: Any = None
+    ) -> None:
         start_time = time.time()
 
         with tracer.start_as_current_span(
@@ -583,7 +585,9 @@ def _instrument_tool_proxy(
                         client_params = ctx.session.client_params
                         if client_params is not None:
                             span.set_attribute("mcp.client.name", client_params.clientInfo.name)
-                            span.set_attribute("mcp.client.version", client_params.clientInfo.version)
+                            span.set_attribute(
+                                "mcp.client.version", client_params.clientInfo.version
+                            )
                     except AttributeError:
                         pass
 

--- a/mcp_compose/otel.py
+++ b/mcp_compose/otel.py
@@ -566,7 +566,7 @@ def _instrument_tool_proxy(
     original_discover_tools = ToolProxy.discover_tools
 
     @functools.wraps(original_discover_tools)
-    async def traced_discover_tools(self: Any, server_name: str, process: Any) -> None:
+    async def traced_discover_tools(self: Any, server_name: str, process: Any, ctx: Any = None) -> None:
         start_time = time.time()
 
         with tracer.start_as_current_span(
@@ -578,7 +578,16 @@ def _instrument_tool_proxy(
             span.set_attribute("rpc.system", "jsonrpc")
 
             try:
-                result = await original_discover_tools(self, server_name, process)
+                if ctx is not None:
+                    try:
+                        client_params = ctx.session.client_params
+                        if client_params is not None:
+                            span.set_attribute("mcp.client.name", client_params.clientInfo.name)
+                            span.set_attribute("mcp.client.version", client_params.clientInfo.version)
+                    except AttributeError:
+                        pass
+
+                result = await original_discover_tools(self, server_name, process, ctx=ctx)
 
                 # Record discovered tools count
                 tools_count = 0

--- a/mcp_compose/tool_proxy.py
+++ b/mcp_compose/tool_proxy.py
@@ -14,8 +14,10 @@ import json
 import logging
 from typing import Any
 
+from mcp.server.fastmcp import Context
 from mcp.server.fastmcp.tools.base import Tool
 
+from .client_info import resolve_client_info
 from .process import Process
 from .process_manager import ProcessManager
 
@@ -42,7 +44,7 @@ class ToolProxy:
         self.composer = composer
         self.server_tools: dict[str, dict[str, Any]] = {}
 
-    async def discover_tools(self, server_name: str, process: Process) -> None:
+    async def discover_tools(self, server_name: str, process: Process, ctx: Any = None) -> None:
         """
         Discover tools from a child MCP server via STDIO.
 
@@ -54,6 +56,7 @@ class ToolProxy:
             logger.info(f"Starting tool discovery for {server_name}")
 
             # Send MCP initialize request
+            client_info = resolve_client_info(ctx)
             init_request = {
                 "jsonrpc": "2.0",
                 "id": 1,
@@ -61,7 +64,7 @@ class ToolProxy:
                 "params": {
                     "protocolVersion": "2024-11-05",
                     "capabilities": {"tools": {}},
-                    "clientInfo": {"name": "mcp-compose", "version": "0.1.0"},
+                    "clientInfo": {"name": client_info.name, "version": client_info.version},
                 },
             }
 
@@ -180,8 +183,13 @@ class ToolProxy:
             # Add return annotation
             annotations["return"] = str
 
+            # ctx is injected by FastMCP at call time; exclude from tool schema
+            ctx_param = inspect.Parameter(
+                "ctx", inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=Context
+            )
+
             # Create the actual async function that will be called
-            async def _proxy_impl(**kwargs) -> str:
+            async def _proxy_impl(ctx: Context = None, **kwargs) -> str:
                 """Proxy function that forwards tool calls to child process."""
                 try:
                     logger.info(f"Tool {tl_name} called with arguments: {kwargs}")
@@ -223,15 +231,17 @@ class ToolProxy:
 
             # Create wrapper function with proper signature
             # This function will have the correct parameters in its signature
-            async def proxy_tool(*args, **kwargs) -> str:
+            async def proxy_tool(ctx: Context = None, *args, **kwargs) -> str:
                 # Convert positional args to kwargs based on parameter order
                 for i, param in enumerate(params):
                     if i < len(args):
                         kwargs[param.name] = args[i]
-                return await _proxy_impl(**kwargs)
+                return await _proxy_impl(ctx=ctx, **kwargs)
 
-            # Set the proper signature on the wrapper
-            proxy_tool.__signature__ = inspect.Signature(parameters=params, return_annotation=str)
+            # Set the proper signature on the wrapper — ctx first, then tool params
+            proxy_tool.__signature__ = inspect.Signature(
+                parameters=[ctx_param] + params, return_annotation=str
+            )
             proxy_tool.__annotations__ = annotations
 
             return proxy_tool

--- a/tests/test_cli_proxy_client_info.py
+++ b/tests/test_cli_proxy_client_info.py
@@ -6,7 +6,6 @@ Tests for upstream clientInfo propagation through SSE and Streamable HTTP proxy 
 """
 
 import asyncio
-import sys
 
 import pytest
 import uvicorn
@@ -53,7 +52,6 @@ async def _start_uvicorn(app, port: int):
 
 
 class TestSseProxyClientInfo:
-
     @pytest.mark.asyncio
     async def test_sse_proxy_passes_upstream_client_info(self):
         port = 19201
@@ -125,7 +123,6 @@ class TestSseProxyClientInfo:
 
 
 class TestStreamableHttpProxyClientInfo:
-
     @pytest.mark.asyncio
     async def test_streamable_http_proxy_passes_upstream_client_info(self):
         port = 19203

--- a/tests/test_cli_proxy_client_info.py
+++ b/tests/test_cli_proxy_client_info.py
@@ -1,0 +1,212 @@
+# Copyright (c) 2025-2026 Datalayer, Inc.
+# Distributed under the terms of the Modified BSD License.
+
+"""
+Tests for upstream clientInfo propagation through SSE and Streamable HTTP proxy paths.
+"""
+
+import asyncio
+import sys
+
+import pytest
+import uvicorn
+from mcp.server.fastmcp import Context, FastMCP
+from mcp.types import Implementation
+
+
+def _make_ctx(name: str = "test-agent", version: str = "2.0.0"):
+    from unittest.mock import MagicMock
+
+    info = Implementation(name=name, version=version)
+    client_params = MagicMock()
+    client_params.clientInfo = info
+    session = MagicMock()
+    session.client_params = client_params
+    ctx = MagicMock()
+    ctx.session = session
+    return ctx
+
+
+def _build_sub_server(port: int):
+    received = {}
+    sub = FastMCP("sub-server")
+
+    @sub.tool()
+    async def ping(ctx: Context) -> str:
+        if ctx and ctx.session and ctx.session.client_params:
+            received["name"] = ctx.session.client_params.clientInfo.name
+            received["version"] = ctx.session.client_params.clientInfo.version
+        return "pong"
+
+    return sub, received
+
+
+async def _start_uvicorn(app, port: int):
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error")
+    server = uvicorn.Server(config)
+    task = asyncio.create_task(server.serve())
+    for _ in range(100):
+        await asyncio.sleep(0.05)
+        if server.started:
+            break
+    return server, task
+
+
+class TestSseProxyClientInfo:
+
+    @pytest.mark.asyncio
+    async def test_sse_proxy_passes_upstream_client_info(self):
+        port = 19201
+        sub, received = _build_sub_server(port)
+        userver, server_task = await _start_uvicorn(sub.sse_app(), port)
+
+        try:
+            from mcp import ClientSession
+            from mcp.client.sse import sse_client
+
+            sse_url = f"http://127.0.0.1:{port}/sse"
+            ctx = _make_ctx(name="upstream-llm", version="4.2.0")
+
+            async def sse_tool_proxy(ctx=None, **kwargs):
+                from mcp_compose.client_info import resolve_client_info
+
+                client_info = resolve_client_info(ctx)
+                async with sse_client(sse_url) as (read, write):
+                    async with ClientSession(read, write, client_info=client_info) as session:
+                        await session.initialize()
+                        result = await session.call_tool("ping", kwargs)
+                        if hasattr(result, "content") and result.content:
+                            for item in result.content:
+                                if hasattr(item, "text"):
+                                    return item.text
+                        return str(result)
+
+            result = await sse_tool_proxy(ctx=ctx)
+
+            assert result == "pong"
+            assert received["name"] == "upstream-llm"
+            assert received["version"] == "4.2.0"
+        finally:
+            userver.should_exit = True
+            await server_task
+
+    @pytest.mark.asyncio
+    async def test_sse_proxy_falls_back_without_ctx(self):
+        port = 19202
+        sub, received = _build_sub_server(port)
+        userver, server_task = await _start_uvicorn(sub.sse_app(), port)
+
+        try:
+            from mcp import ClientSession
+            from mcp.client.sse import sse_client
+
+            sse_url = f"http://127.0.0.1:{port}/sse"
+
+            async def sse_tool_proxy(ctx=None, **kwargs):
+                from mcp_compose.client_info import resolve_client_info
+
+                client_info = resolve_client_info(ctx)
+                async with sse_client(sse_url) as (read, write):
+                    async with ClientSession(read, write, client_info=client_info) as session:
+                        await session.initialize()
+                        result = await session.call_tool("ping", kwargs)
+                        if hasattr(result, "content") and result.content:
+                            for item in result.content:
+                                if hasattr(item, "text"):
+                                    return item.text
+                        return str(result)
+
+            await sse_tool_proxy(ctx=None)
+
+            assert received["name"] == "mcp-compose"
+        finally:
+            userver.should_exit = True
+            await server_task
+
+
+class TestStreamableHttpProxyClientInfo:
+
+    @pytest.mark.asyncio
+    async def test_streamable_http_proxy_passes_upstream_client_info(self):
+        port = 19203
+        sub, received = _build_sub_server(port)
+        userver, server_task = await _start_uvicorn(sub.streamable_http_app(), port)
+
+        try:
+            from mcp import ClientSession
+
+            from mcp_compose.client_info import resolve_client_info
+            from mcp_compose.http_client import streamable_http_client_compat
+
+            http_url = f"http://127.0.0.1:{port}/mcp"
+            ctx = _make_ctx(name="streaming-agent", version="1.0.0")
+
+            async def streamable_http_tool_proxy(ctx=None, **kwargs):
+                client_info = resolve_client_info(ctx)
+                async with streamable_http_client_compat(url=http_url) as (
+                    read_stream,
+                    write_stream,
+                    _get_session_id,
+                ):
+                    async with ClientSession(
+                        read_stream, write_stream, client_info=client_info
+                    ) as session:
+                        await session.initialize()
+                        result = await session.call_tool("ping", kwargs)
+                        if hasattr(result, "content") and result.content:
+                            for item in result.content:
+                                if hasattr(item, "text"):
+                                    return item.text
+                        return str(result)
+
+            result = await streamable_http_tool_proxy(ctx=ctx)
+
+            assert result == "pong"
+            assert received["name"] == "streaming-agent"
+            assert received["version"] == "1.0.0"
+        finally:
+            userver.should_exit = True
+            await server_task
+
+    @pytest.mark.asyncio
+    async def test_streamable_http_proxy_falls_back_without_ctx(self):
+        port = 19204
+        sub, received = _build_sub_server(port)
+        userver, server_task = await _start_uvicorn(sub.streamable_http_app(), port)
+
+        try:
+            from mcp import ClientSession
+
+            from mcp_compose.client_info import resolve_client_info
+            from mcp_compose.http_client import streamable_http_client_compat
+
+            http_url = f"http://127.0.0.1:{port}/mcp"
+
+            async def streamable_http_tool_proxy(ctx=None, **kwargs):
+                client_info = resolve_client_info(ctx)
+                async with streamable_http_client_compat(url=http_url) as (
+                    read_stream,
+                    write_stream,
+                    _get_session_id,
+                ):
+                    async with ClientSession(
+                        read_stream, write_stream, client_info=client_info
+                    ) as session:
+                        await session.initialize()
+                        result = await session.call_tool("ping", kwargs)
+                        if hasattr(result, "content") and result.content:
+                            for item in result.content:
+                                if hasattr(item, "text"):
+                                    return item.text
+                        return str(result)
+
+            await streamable_http_tool_proxy(ctx=None)
+
+            assert received["name"] == "mcp-compose"
+        finally:
+            userver.should_exit = True
+            await server_task
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_tool_proxy_client_info.py
+++ b/tests/test_tool_proxy_client_info.py
@@ -12,7 +12,7 @@ import pytest
 
 from mcp_compose.client_info import FALLBACK_CLIENT_INFO, resolve_client_info
 
-RECORDING_MCP_SERVER = '''
+RECORDING_MCP_SERVER = """
 import sys
 import json
 
@@ -56,7 +56,7 @@ def main():
 
 if __name__ == "__main__":
     main()
-'''
+"""
 
 
 def _make_ctx(name: str = "test-agent", version: str = "2.0.0"):
@@ -82,7 +82,6 @@ def recording_script(tmp_path):
 
 
 class TestResolveClientInfo:
-
     def test_returns_fallback_when_ctx_is_none(self):
         result = resolve_client_info(None)
         assert result is FALLBACK_CLIENT_INFO
@@ -111,13 +110,11 @@ class TestResolveClientInfo:
 
 
 class TestToolProxyDiscoverToolsClientInfo:
-
     @pytest.mark.asyncio
     async def test_discover_tools_sends_upstream_client_info(self, recording_script):
         from unittest.mock import MagicMock
 
         from mcp_compose.composer import MCPServerComposer
-        from mcp_compose.process import Process
         from mcp_compose.process_manager import ProcessManager
         from mcp_compose.tool_proxy import ToolProxy
 
@@ -197,11 +194,11 @@ class TestToolProxyDiscoverToolsClientInfo:
 
 
 class TestToolProxyProxyFunctionSignature:
-
     def test_proxy_function_has_ctx_parameter(self, recording_script):
         from unittest.mock import MagicMock
 
         from mcp.server.fastmcp import Context
+
         from mcp_compose.composer import MCPServerComposer
         from mcp_compose.process import Process
         from mcp_compose.process_manager import ProcessManager

--- a/tests/test_tool_proxy_client_info.py
+++ b/tests/test_tool_proxy_client_info.py
@@ -1,0 +1,277 @@
+# Copyright (c) 2025-2026 Datalayer, Inc.
+# Distributed under the terms of the Modified BSD License.
+
+"""
+Tests for upstream clientInfo propagation through the STDIO ToolProxy path.
+"""
+
+import inspect
+import sys
+
+import pytest
+
+from mcp_compose.client_info import FALLBACK_CLIENT_INFO, resolve_client_info
+
+RECORDING_MCP_SERVER = '''
+import sys
+import json
+
+def main():
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        msg = json.loads(line)
+        method = msg.get("method", "")
+
+        if method == "initialize":
+            client_info = msg["params"].get("clientInfo", {})
+            print(json.dumps({
+                "jsonrpc": "2.0",
+                "id": msg["id"],
+                "result": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {},
+                    "serverInfo": {"name": "recording-server", "version": "0.1.0"},
+                    "clientInfoReceived": client_info,
+                }
+            }), flush=True)
+
+        elif method == "notifications/initialized":
+            pass
+
+        elif method == "tools/list":
+            print(json.dumps({
+                "jsonrpc": "2.0",
+                "id": msg["id"],
+                "result": {"tools": []}
+            }), flush=True)
+
+        elif method == "tools/call":
+            print(json.dumps({
+                "jsonrpc": "2.0",
+                "id": msg["id"],
+                "result": {"content": [{"type": "text", "text": "ok"}]}
+            }), flush=True)
+
+if __name__ == "__main__":
+    main()
+'''
+
+
+def _make_ctx(name: str = "test-agent", version: str = "2.0.0"):
+    from unittest.mock import MagicMock
+
+    from mcp.types import Implementation
+
+    info = Implementation(name=name, version=version)
+    client_params = MagicMock()
+    client_params.clientInfo = info
+    session = MagicMock()
+    session.client_params = client_params
+    ctx = MagicMock()
+    ctx.session = session
+    return ctx
+
+
+@pytest.fixture
+def recording_script(tmp_path):
+    script = tmp_path / "recording_server.py"
+    script.write_text(RECORDING_MCP_SERVER)
+    return str(script)
+
+
+class TestResolveClientInfo:
+
+    def test_returns_fallback_when_ctx_is_none(self):
+        result = resolve_client_info(None)
+        assert result is FALLBACK_CLIENT_INFO
+        assert result.name == "mcp-compose"
+
+    def test_returns_fallback_when_client_params_is_none(self):
+        from unittest.mock import MagicMock
+
+        session = MagicMock()
+        session.client_params = None
+        ctx = MagicMock()
+        ctx.session = session
+
+        result = resolve_client_info(ctx)
+        assert result is FALLBACK_CLIENT_INFO
+
+    def test_returns_fallback_on_attribute_error(self):
+        result = resolve_client_info(object())
+        assert result is FALLBACK_CLIENT_INFO
+
+    def test_returns_upstream_client_info(self):
+        ctx = _make_ctx(name="my-llm", version="9.9.9")
+        result = resolve_client_info(ctx)
+        assert result.name == "my-llm"
+        assert result.version == "9.9.9"
+
+
+class TestToolProxyDiscoverToolsClientInfo:
+
+    @pytest.mark.asyncio
+    async def test_discover_tools_sends_upstream_client_info(self, recording_script):
+        from unittest.mock import MagicMock
+
+        from mcp_compose.composer import MCPServerComposer
+        from mcp_compose.process import Process
+        from mcp_compose.process_manager import ProcessManager
+        from mcp_compose.tool_proxy import ToolProxy
+
+        process_manager = ProcessManager()
+        composer = MagicMock()
+        composer.conflict_resolution = MCPServerComposer().conflict_resolution
+        composer.composed_tools = {}
+        composer.source_mapping = {}
+        composer.composed_server = MagicMock()
+        composer.composed_server._tool_manager._tools = {}
+
+        tool_proxy = ToolProxy(process_manager, composer)
+        process = await process_manager.add_process(
+            name="recording",
+            command=[sys.executable, recording_script],
+            auto_start=True,
+        )
+
+        ctx = _make_ctx(name="upstream-agent", version="3.1.4")
+        captured_init = {}
+
+        original_send = tool_proxy._send_request
+
+        async def capturing_send(proc, request, timeout=5.0):
+            if request.get("method") == "initialize":
+                captured_init.update(request["params"].get("clientInfo", {}))
+            return await original_send(proc, request, timeout)
+
+        tool_proxy._send_request = capturing_send
+
+        await tool_proxy.discover_tools("recording", process, ctx=ctx)
+
+        assert captured_init["name"] == "upstream-agent"
+        assert captured_init["version"] == "3.1.4"
+
+        await process_manager.stop_process("recording")
+
+    @pytest.mark.asyncio
+    async def test_discover_tools_uses_fallback_without_ctx(self, recording_script):
+        from unittest.mock import MagicMock
+
+        from mcp_compose.composer import MCPServerComposer
+        from mcp_compose.process_manager import ProcessManager
+        from mcp_compose.tool_proxy import ToolProxy
+
+        process_manager = ProcessManager()
+        composer = MagicMock()
+        composer.conflict_resolution = MCPServerComposer().conflict_resolution
+        composer.composed_tools = {}
+        composer.source_mapping = {}
+        composer.composed_server = MagicMock()
+        composer.composed_server._tool_manager._tools = {}
+
+        tool_proxy = ToolProxy(process_manager, composer)
+        process = await process_manager.add_process(
+            name="recording2",
+            command=[sys.executable, recording_script],
+            auto_start=True,
+        )
+
+        captured_init = {}
+
+        original_send = tool_proxy._send_request
+
+        async def capturing_send(proc, request, timeout=5.0):
+            if request.get("method") == "initialize":
+                captured_init.update(request["params"].get("clientInfo", {}))
+            return await original_send(proc, request, timeout)
+
+        tool_proxy._send_request = capturing_send
+
+        await tool_proxy.discover_tools("recording2", process, ctx=None)
+
+        assert captured_init["name"] == "mcp-compose"
+
+        await process_manager.stop_process("recording2")
+
+
+class TestToolProxyProxyFunctionSignature:
+
+    def test_proxy_function_has_ctx_parameter(self, recording_script):
+        from unittest.mock import MagicMock
+
+        from mcp.server.fastmcp import Context
+        from mcp_compose.composer import MCPServerComposer
+        from mcp_compose.process import Process
+        from mcp_compose.process_manager import ProcessManager
+        from mcp_compose.tool_proxy import ToolProxy
+
+        process_manager = ProcessManager()
+        composer = MagicMock()
+        composer.conflict_resolution = MCPServerComposer().conflict_resolution
+        composer.composed_tools = {}
+        composer.source_mapping = {}
+        composer.composed_server = MagicMock()
+        composer.composed_server._tool_manager._tools = {}
+
+        tool_proxy = ToolProxy(process_manager, composer)
+        mock_process = MagicMock(spec=Process)
+
+        tool_def = {
+            "name": "greet",
+            "description": "Say hello",
+            "inputSchema": {
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+                "required": ["name"],
+            },
+        }
+
+        tool_proxy._register_tool_proxy("srv", "greet", tool_def, mock_process)
+
+        registered = composer.composed_server._tool_manager._tools.get("srv_greet")
+        assert registered is not None
+
+        sig = inspect.signature(registered.fn)
+        params = list(sig.parameters.keys())
+        assert "ctx" in params
+        assert sig.parameters["ctx"].annotation is Context
+
+    def test_ctx_not_in_tool_schema(self, recording_script):
+        from unittest.mock import MagicMock
+
+        from mcp_compose.composer import MCPServerComposer
+        from mcp_compose.process import Process
+        from mcp_compose.process_manager import ProcessManager
+        from mcp_compose.tool_proxy import ToolProxy
+
+        process_manager = ProcessManager()
+        composer = MagicMock()
+        composer.conflict_resolution = MCPServerComposer().conflict_resolution
+        composer.composed_tools = {}
+        composer.source_mapping = {}
+        composer.composed_server = MagicMock()
+        composer.composed_server._tool_manager._tools = {}
+
+        tool_proxy = ToolProxy(process_manager, composer)
+        mock_process = MagicMock(spec=Process)
+
+        tool_def = {
+            "name": "greet",
+            "description": "Say hello",
+            "inputSchema": {
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+                "required": ["name"],
+            },
+        }
+
+        tool_proxy._register_tool_proxy("srv", "greet", tool_def, mock_process)
+        registered = composer.composed_server._tool_manager._tools.get("srv_greet")
+        assert registered is not None
+        assert "ctx" not in registered.parameters.get("properties", {})
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Here the clientInfo from the MCP client (AI Agent) that calls an mcp-composed server will be passed along to each tool call. This would ensure that if the individual composed MCPs, developed independently, capture tool call logs then they can send along the correct clientInfo from the AI Agent. 