### PR TITLE
allow --port=8000 to apply as override

### DIFF
--- a/mcp_compose/cli.py
+++ b/mcp_compose/cli.py
@@ -1377,17 +1377,12 @@ async def run_server(config, args: argparse.Namespace) -> int:
         from .api import create_app
         from .api.dependencies import set_composer, set_config
 
-        # Determine port priority: CLI arg (if explicitly set) > composer config > default
-        # Note: 8000 is the argparse default for serve command
-        if hasattr(args, "port") and args.port != 8000:
-            # CLI arg was explicitly provided
+        if args.port is not None:
             server_port = args.port
         elif config.composer and config.composer.port:
-            # Use composer config port
             server_port = config.composer.port
         else:
-            # Fall back to default
-            server_port = args.port
+            server_port = 8000
 
         # Determine UI port (for logging purposes)
         ui_port = server_port  # Default: UI on same port as transport
@@ -1648,7 +1643,7 @@ def create_parser() -> argparse.ArgumentParser:
     serve_parser.add_argument(
         "--port",
         type=int,
-        default=8000,
+        default=None,
         help="Port to bind to (default: 8000)",
     )
     serve_parser.add_argument(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -379,14 +379,18 @@ class TestCLI:
         config = MCPComposerConfig(composer=ComposerConfig(port=9090))
 
         parser = create_parser()
-        args = parser.parse_args(["serve", "--port", str(cli_port), "--transport", "streamable-http"])
+        args = parser.parse_args(
+            ["serve", "--port", str(cli_port), "--transport", "streamable-http"]
+        )
         args.config = None
         args.config_path = None
         args.verbose = False
 
-        with patch("mcp_compose.cli.load_config", return_value=config), \
-             patch("mcp_compose.cli.find_config_file", return_value=Path("fake.toml")), \
-             patch("uvicorn.Server", return_value=mock_uvicorn_server):
+        with (
+            patch("mcp_compose.cli.load_config", return_value=config),
+            patch("mcp_compose.cli.find_config_file", return_value=Path("fake.toml")),
+            patch("uvicorn.Server", return_value=mock_uvicorn_server),
+        ):
             serve_command(args)
 
         _, kwargs = mock_uvicorn_config.call_args

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,7 +9,7 @@ import json
 import tempfile
 from io import StringIO
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
@@ -21,7 +21,9 @@ from mcp_compose.cli import (
     main,
     print_discovery_results,
     print_summary,
+    serve_command,
 )
+from mcp_compose.config import ComposerConfig, MCPComposerConfig
 
 
 class TestCLI:
@@ -322,6 +324,76 @@ class TestCLI:
 
         assert result == 0
         mock_discover.assert_called_once_with(mock_args)
+
+    def test_parser_serve_port_default(self):
+        """Test serve command --port defaults to None (unset) when not provided."""
+        parser = create_parser()
+
+        args = parser.parse_args(["serve"])
+
+        assert args.port is None
+
+    def test_parser_serve_port_explicit_non_default(self):
+        """Test serve command --port accepts an explicit non-default value."""
+        parser = create_parser()
+
+        args = parser.parse_args(["serve", "--port", "9000"])
+
+        assert args.port == 9000
+
+    @pytest.mark.parametrize("cli_port", [8000, 9000])
+    @patch("uvicorn.Config")
+    @patch("mcp_compose.cli.setup_otel_tracing")
+    @patch("mcp_compose.api.dependencies.set_authenticator")
+    @patch("mcp_compose.api.dependencies.set_config")
+    @patch("mcp_compose.api.dependencies.set_composer")
+    @patch("mcp_compose.api.create_app")
+    @patch("mcp_compose.cli.MCPServerComposer")
+    def test_serve_port_overrides_toml(
+        self,
+        mock_composer_class,
+        mock_create_app,
+        mock_set_composer,
+        mock_set_config,
+        mock_set_authenticator,
+        mock_setup_otel,
+        mock_uvicorn_config,
+        cli_port,
+    ):
+        """--port=<N> passed on CLI must override the port in TOML config."""
+        mock_composer = MagicMock()
+        mock_composer.composed_tools = {}
+        mock_composer.composed_server.streamable_http_app.return_value = MagicMock(routes=[])
+        mock_composer_class.return_value = mock_composer
+
+        mock_app = MagicMock()
+        mock_app.routes = []
+        mock_create_app.return_value = mock_app
+
+        mock_setup_otel.return_value = None
+
+        mock_uvicorn_server = AsyncMock()
+        mock_uvicorn_server.serve = AsyncMock()
+        mock_uvicorn_config.return_value = MagicMock()
+
+        config = MCPComposerConfig(composer=ComposerConfig(port=9090))
+
+        parser = create_parser()
+        args = parser.parse_args(["serve", "--port", str(cli_port), "--transport", "streamable-http"])
+        args.config = None
+        args.config_path = None
+        args.verbose = False
+
+        with patch("mcp_compose.cli.load_config", return_value=config), \
+             patch("mcp_compose.cli.find_config_file", return_value=Path("fake.toml")), \
+             patch("uvicorn.Server", return_value=mock_uvicorn_server):
+            serve_command(args)
+
+        _, kwargs = mock_uvicorn_config.call_args
+        assert kwargs["port"] == cli_port, (
+            f"Expected uvicorn to bind on port {cli_port} (explicit CLI flag), "
+            f"but got {kwargs['port']} (TOML config port leaked through)"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_cli_proxy_client_info.py
+++ b/tests/test_cli_proxy_client_info.py
@@ -5,8 +5,9 @@
 Tests for upstream clientInfo propagation through SSE and Streamable HTTP proxy paths.
 """
 
-import asyncio
+from contextlib import asynccontextmanager
 
+import anyio
 import pytest
 import uvicorn
 from mcp.server.fastmcp import Context, FastMCP
@@ -40,15 +41,18 @@ def _build_sub_server(port: int):
     return sub, received
 
 
-async def _start_uvicorn(app, port: int):
+@asynccontextmanager
+async def _run_uvicorn(app, port: int):
     config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error")
     server = uvicorn.Server(config)
-    task = asyncio.create_task(server.serve())
-    for _ in range(100):
-        await asyncio.sleep(0.05)
-        if server.started:
-            break
-    return server, task
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(server.serve)
+        for _ in range(100):
+            await anyio.sleep(0.05)
+            if server.started:
+                break
+        yield server
+        server.should_exit = True
 
 
 class TestSseProxyClientInfo:
@@ -56,9 +60,7 @@ class TestSseProxyClientInfo:
     async def test_sse_proxy_passes_upstream_client_info(self):
         port = 19201
         sub, received = _build_sub_server(port)
-        userver, server_task = await _start_uvicorn(sub.sse_app(), port)
-
-        try:
+        async with _run_uvicorn(sub.sse_app(), port):
             from mcp import ClientSession
             from mcp.client.sse import sse_client
 
@@ -84,17 +86,12 @@ class TestSseProxyClientInfo:
             assert result == "pong"
             assert received["name"] == "upstream-llm"
             assert received["version"] == "4.2.0"
-        finally:
-            userver.should_exit = True
-            await server_task
 
     @pytest.mark.asyncio
     async def test_sse_proxy_falls_back_without_ctx(self):
         port = 19202
         sub, received = _build_sub_server(port)
-        userver, server_task = await _start_uvicorn(sub.sse_app(), port)
-
-        try:
+        async with _run_uvicorn(sub.sse_app(), port):
             from mcp import ClientSession
             from mcp.client.sse import sse_client
 
@@ -117,9 +114,6 @@ class TestSseProxyClientInfo:
             await sse_tool_proxy(ctx=None)
 
             assert received["name"] == "mcp-compose"
-        finally:
-            userver.should_exit = True
-            await server_task
 
 
 class TestStreamableHttpProxyClientInfo:
@@ -127,9 +121,7 @@ class TestStreamableHttpProxyClientInfo:
     async def test_streamable_http_proxy_passes_upstream_client_info(self):
         port = 19203
         sub, received = _build_sub_server(port)
-        userver, server_task = await _start_uvicorn(sub.streamable_http_app(), port)
-
-        try:
+        async with _run_uvicorn(sub.streamable_http_app(), port):
             from mcp import ClientSession
 
             from mcp_compose.client_info import resolve_client_info
@@ -161,17 +153,12 @@ class TestStreamableHttpProxyClientInfo:
             assert result == "pong"
             assert received["name"] == "streaming-agent"
             assert received["version"] == "1.0.0"
-        finally:
-            userver.should_exit = True
-            await server_task
 
     @pytest.mark.asyncio
     async def test_streamable_http_proxy_falls_back_without_ctx(self):
         port = 19204
         sub, received = _build_sub_server(port)
-        userver, server_task = await _start_uvicorn(sub.streamable_http_app(), port)
-
-        try:
+        async with _run_uvicorn(sub.streamable_http_app(), port):
             from mcp import ClientSession
 
             from mcp_compose.client_info import resolve_client_info
@@ -200,9 +187,6 @@ class TestStreamableHttpProxyClientInfo:
             await streamable_http_tool_proxy(ctx=None)
 
             assert received["name"] == "mcp-compose"
-        finally:
-            userver.should_exit = True
-            await server_task
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I found out that when `--port=8000` was explicitly provided on the CLI it would not override the mcp-compose.toml configuration but any other value would.

This PR helps declare that when no `--port` flag is passed the mcp-compose.toml is used otherwise set the port to 8000. But when --port is passed it has the highest priority.

Here's an example of the case today with version 0.1.11

## no port override 

```text
❯ mcp-compose serve -c examples/proxy-streamable-http/mcp_compose.toml
...
======================================================================
📡 MCP Server Mode: STREAMABLE-HTTP
======================================================================
  MCP Endpoint:  http://localhost:8888/mcp
  Tools List:    http://localhost:8888/tools
  REST API:      http://localhost:8888/api/v1
  Health Check:  http://localhost:8888/api/v1/health
  Web UI:        http://localhost:9456/ui
```

## with port=8000 override

the mcp endpoint is still on 8888

```text
❯ mcp-compose serve -c examples/proxy-streamable-http/mcp_compose.toml --port 8000
======================================================================
📡 MCP Server Mode: STREAMABLE-HTTP
======================================================================
  MCP Endpoint:  http://localhost:8888/mcp
  Tools List:    http://localhost:8888/tools
  REST API:      http://localhost:8888/api/v1
  Health Check:  http://localhost:8888/api/v1/health
  Web UI:        http://localhost:9456/ui
```

