### PR TITLE
Build the python wheel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,23 +20,18 @@ COPY ui/ ./
 # Build UI
 RUN npm run build
 
-# Stage 2: Python dependencies
+# Stage 2: Build Python wheel
 FROM python:3.10-slim AS python-builder
 
 WORKDIR /build
 
-# Install build dependencies
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    && rm -rf /var/lib/apt/lists/*
-
 # Copy Python package files
 COPY pyproject.toml README.md LICENSE hatch_build.py ./
 COPY mcp_compose/ ./mcp_compose/
-COPY tests/ ./tests/
 
-# Install Python dependencies
-RUN pip install --user --no-cache-dir -e .
+# Build the wheel
+RUN pip install --upgrade build \
+    && python -m build --wheel --outdir dist
 
 # Stage 3: Runtime
 FROM python:3.10-slim
@@ -48,21 +43,15 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /app
 
-# Copy Python installation from builder
-COPY --from=python-builder /root/.local /root/.local
+# Copy and install the wheel from the builder stage
+COPY --from=python-builder /build/dist/*.whl /tmp/
+RUN pip install --no-cache-dir /tmp/*.whl && rm /tmp/*.whl
 
 # Copy UI build from ui-builder
 COPY --from=ui-builder /ui/dist /app/ui/dist
 
-# Copy application code
-COPY mcp_compose/ /app/mcp_compose/
-COPY pyproject.toml README.md /app/
-
 # Copy example configuration
 COPY examples/ui/mcp_compose.toml /app/config.toml
-
-# Make sure scripts in .local are usable
-ENV PATH=/root/.local/bin:$PATH
 
 # Create directories
 RUN mkdir -p /var/log/mcp-compose /data /etc/mcp-compose

--- a/mcp_compose/api/app.py
+++ b/mcp_compose/api/app.py
@@ -234,7 +234,7 @@ def register_routes(app: FastAPI) -> None:
     app.include_router(settings.router, prefix="/api/v1", tags=["settings"])
 
     # Serve UI static files if available
-    ui_dist_path = Path(__file__).parent.parent.parent / "ui" / "dist"
+    ui_dist_path = Path.cwd() / "ui" / "dist"
     if ui_dist_path.exists() and ui_dist_path.is_dir():
         logger.info(f"Serving UI from {ui_dist_path}")
 


### PR DESCRIPTION
Fixes #36 

## What it's doing right now
Copy module src to **stage 2**
Install on **stage 2**, python makes aliases on `/root/.local` (inaccessible)
Copy module src to **stage 3**
Copy aliases from **stage 2**


## What this does
Make wheel on **stage 2**
Copy wheel from **stage 2** to **stage 3**
Install wheel in **stage 3**
Point `./ui/dist` to current working directory (`/app`)

## Docker logs:
```log
Loading configuration from: /app/config.toml

🔐 Authentication enabled
   Provider: basic
   ⚠️  Warning: Provider basic not yet implemented

2026-05-03 18:08:57 - mcp_compose.process_manager - INFO - Starting ProcessManager

🚀 MCP Compose: demo-composer
Conflict Resolution: prefix
Log Level: INFO

Starting 2 server(s)...

  • calculator
    Command: python mcp1.py
2026-05-03 18:08:57 - mcp_compose.process_manager - INFO - Adding process calculator
2026-05-03 18:08:57 - mcp_compose.process - INFO - Starting process calculator: python mcp1.py
2026-05-03 18:08:57 - mcp_compose.process - INFO - Process calculator started with PID 7
2026-05-03 18:08:57 - mcp_compose.tool_proxy - INFO - Starting tool discovery for calculator
2026-05-03 18:08:57 - mcp_compose.tool_proxy - WARNING - Empty response from calculator
2026-05-03 18:08:57 - mcp_compose.tool_proxy - ERROR - No response to initialize from calculator
    Status: ✓ Started

  • echo
    Command: python mcp2.py
2026-05-03 18:08:57 - mcp_compose.process_manager - INFO - Adding process echo
2026-05-03 18:08:57 - mcp_compose.process - INFO - Starting process echo: python mcp2.py
2026-05-03 18:08:57 - mcp_compose.process - INFO - Process echo started with PID 9
2026-05-03 18:08:57 - mcp_compose.tool_proxy - INFO - Starting tool discovery for echo
2026-05-03 18:08:57 - mcp_compose.tool_proxy - WARNING - Empty response from echo
2026-05-03 18:08:57 - mcp_compose.tool_proxy - ERROR - No response to initialize from echo
    Status: ✓ Started

✓ All servers started successfully!

2026-05-03 18:08:57 - mcp_compose.api.app - INFO - Serving UI from /app/ui/dist
2026-05-03 18:08:57 - mcp_compose.cli - INFO - Streamable HTTP app has 1 routes
2026-05-03 18:08:57 - mcp_compose.cli - INFO - Streamable HTTP routes added successfully to main app
======================================================================
📡 MCP Server Mode: STREAMABLE-HTTP
======================================================================
  MCP Endpoint:  http://localhost:8080/mcp
  Tools List:    http://localhost:8080/tools
  REST API:      http://localhost:8080/api/v1
  Health Check:  http://localhost:8080/api/v1/health
  Web UI:        http://localhost:8080/ui

✓ Unified MCP server is now running!
  Total tools: 0


======================================================================

Press Ctrl+C to stop all servers...

INFO:     Started server process [1]
INFO:     Waiting for application startup.
2026-05-03 18:08:57 - mcp_compose.cli - INFO - Starting MCP Compose API
2026-05-03 18:08:57 - mcp.server.streamable_http_manager - INFO - StreamableHTTP session manager started
2026-05-03 18:08:57 - mcp_compose.cli - INFO - Streamable HTTP session manager started
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:8080 (Press CTRL+C to quit)
```